### PR TITLE
add new field / metric to the exporter

### DIFF
--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -19,6 +19,10 @@ func NewCollector(client shelly.Client, log *zap.Logger) *Collector {
 			"Current real AC power being drawn, in Watts",
 			[]string{"device", "meter"}, nil,
 		),
+		TotalWattMinutes: prometheus.NewDesc("shelly_meter_total_wattminutes",
+			"Total energy consumed by the attached electrical appliance in Watt-minute",
+			[]string{"device", "meter"}, nil,
+		),
 		RelayOn: prometheus.NewDesc("shelly_relay_on",
 			"Whether the channel is turned ON or OFF",
 			[]string{"device", "relay"}, nil,
@@ -107,6 +111,7 @@ type Collector struct {
 	TargetTemperature  *prometheus.Desc
 	TargetEnabled      *prometheus.Desc
 	BatteryStatus      *prometheus.Desc
+	TotalWattMinutes   *prometheus.Desc
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
@@ -170,6 +175,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	for i, meter := range status.Meters {
 		meterID := strconv.Itoa(i)
 		ch <- prometheus.MustNewConstMetric(c.MeterPower, prometheus.GaugeValue, meter.Power,
+			status.MAC, meterID)
+		ch <- prometheus.MustNewConstMetric(c.TotalWattMinutes, prometheus.CounterValue, meter.Total,
 			status.MAC, meterID)
 	}
 

--- a/pkg/shelly/model.go
+++ b/pkg/shelly/model.go
@@ -22,6 +22,7 @@ type Status struct {
 
 type Meter struct {
 	Power float64
+	Total float64
 }
 
 type Relay struct {


### PR DESCRIPTION
I've added a new counter metric for watt-minutes to enhance the accuracy of energy consumption measurements. This provides a more precise alternative to averaging over time, addressing the limitations of Prometheus's estimation methods.
